### PR TITLE
Fix terminal detection bug

### DIFF
--- a/moteur_graphique.py
+++ b/moteur_graphique.py
@@ -2,9 +2,13 @@ from math import floor
 import os
 from lib_math import *
 
-width,height = os.get_terminal_size()
-height -= 1
-pixelBuffer = [' ']*(width*height)
+try:
+    width, height = os.get_terminal_size()
+    height -= 1
+except OSError:
+    # Fallback when there's no associated terminal (e.g. during tests)
+    width, height = 80, 24
+pixelBuffer = [' '] * (width * height)
 
 class Camera:
     def __init__(self,position,pitch,yaw,focalLenth=1.5) -> None:
@@ -123,8 +127,7 @@ def loadObj(filePath):
                 vertex = list(map(float,line[1:]))
                 vertices.append(vec3(vertex[0], vertex[1], vertex[2]))
             if line[0] == 'f':
-                print(line[0], line)
-                faces.append(list(map(int,line[1:])))
+                faces.append(list(map(int, line[1:])))
                         
         triangles = []
         for f in faces:


### PR DESCRIPTION
## Summary
- avoid failing on missing terminal size
- remove debugging print when loading OBJ files

## Testing
- `python -m py_compile lib_math.py moteur_graphique.py main.py keyboard_library.py`
- `timeout 2 python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c61e4f148333834a36b5e8e34c8f