### PR TITLE
Handle non-interactive OBJ selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Contributor Guidelines
+
+Please follow these conventions when working with this repository:
+
+- **Style**: Adhere to [PEP 8](https://peps.python.org/pep-0008/) coding style.
+- **Compilation check**: Before committing, run:
+  ```bash
+  python -m py_compile main.py moteur_graphique.py lib_math.py keyboard_library.py
+  ```
+  Ensure there are no compilation errors.
+- **Models**: `.obj` files for 3D models are stored in the `object/` directory.
+- **Running**: Start the engine with:
+  ```bash
+  python main.py
+  ```

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ lamp2 = mg.LightSource(vec3(0, 5, 0), (255, 0, 0),0.4)   # Lampe rouge
 sunlight2 = mg.LightSource(vec3(-4, -20, -20), (255, 255, 170),0.8)  # Soleil jaune
 
 
-lights = [sunlight,lamp,lamp2,sunlight2]
+lights = [sunlight, lamp, lamp2, sunlight2]
 
 
 def select_obj_file() -> str:
@@ -48,6 +48,7 @@ def select_obj_file() -> str:
 
 # Chargement du mesh du cube
 cube = mg.loadObj(select_obj_file())
+
 
 def process_input(controller, dt):
     """
@@ -140,6 +141,9 @@ def main():
     Fonction principale qui initialise le contrôleur clavier et gère la boucle principale.
     """
     print("Appuyez sur les touches pour voir lesquelles sont pressées (Appuyez sur ESC pour quitter).")
+    obj_file = select_obj_file()
+    mesh = mg.loadObj(obj_file)
+
     controller = KeyboardController()  # Initialiser le contrôleur clavier
     t = 0
     try:
@@ -156,8 +160,8 @@ def main():
             # Effacer l'écran
             mg.clear(' ')
 
-            # Afficher le mesh du cube avec la caméra et la lumière
-            mg.putMesh(cube, cam, lights)
+            # Afficher le mesh sélectionné avec la caméra et la lumière
+            mg.putMesh(mesh, cam, lights)
 
             # Dessiner le frame
             mg.draw()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import time
 import platform
+import sys
+import os
 from keyboard_library import KeyboardController  # Importer notre bibliothèque personnalisée
 import moteur_graphique as mg
 from lib_math import *
@@ -17,8 +19,35 @@ sunlight2 = mg.LightSource(vec3(-4, -20, -20), (255, 255, 170),0.8)  # Soleil ja
 
 lights = [sunlight,lamp,lamp2,sunlight2]
 
+
+def select_obj_file() -> str:
+    """Return the name of an OBJ file chosen by the user or automatically."""
+    obj_files = [f for f in os.listdir("object") if f.endswith(".obj")]
+    if not obj_files:
+        raise FileNotFoundError("No .obj files found in 'object' directory")
+
+    if not sys.stdin.isatty():
+        # Non-interactive mode - choose the first file
+        print(f"Automatically selecting {obj_files[0]}")
+        return obj_files[0]
+
+    print("Select an OBJ file:")
+    for idx, name in enumerate(obj_files, start=1):
+        print(f"{idx}. {name}")
+
+    while True:
+        choice = input("Enter number: ")
+        try:
+            index = int(choice) - 1
+        except ValueError:
+            index = -1
+        if 0 <= index < len(obj_files):
+            return obj_files[index]
+        print("Invalid selection. Try again.")
+
+
 # Chargement du mesh du cube
-cube = mg.loadObj("Man.obj")
+cube = mg.loadObj(select_obj_file())
 
 def process_input(controller, dt):
     """

--- a/moteur_graphique.py
+++ b/moteur_graphique.py
@@ -208,6 +208,13 @@ def diffuseLight(lights, normal, vertex, view_pos) -> str:
 
 
 def putMesh(mesh: list[Triangle3D], cam: Camera, lights: list[LightSource]):
+    """Render a mesh using the camera and lighting setup.
+
+    Args:
+        mesh (list[Triangle3D]): Mesh to draw.
+        cam (Camera): Active camera.
+        lights (list[LightSource]): Light sources used for shading.
+    """
     def distanceTriangle(triangle):
         position = (1/3)*(triangle.v1+triangle.v2+triangle.v3)-cam.position
         return position.length()


### PR DESCRIPTION
## Summary
- make `select_obj_file` automatically choose an OBJ file when stdin is not a TTY
- include `sys` and `os` imports for the new logic

## Testing
- `python -m py_compile keyboard_library.py lib_math.py moteur_graphique.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68442a8bed948333ba20a760a1a52847